### PR TITLE
Update vite.config.js to be compatible with default gitea act-runners as well

### DIFF
--- a/Code/02 Basics/02 Starting Project/vite.config.js
+++ b/Code/02 Basics/02 Starting Project/vite.config.js
@@ -8,5 +8,12 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.js',
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/cypress/**',
+      '.{idea,git,cache,output,temp}/**',
+      './src/config/**',
+    ],    
   },
 });


### PR DESCRIPTION
Gitea Actions / Runners seem to use a hidden ".cache" folder by default when checking out the repository. The default vite.config values look for IDE, git and cache folders in the whole path and therefore ignore all the tests.

This change only ignores ide git and cache files from the root source directory

![image](https://github.com/academind/github-actions-course-resources/assets/17900090/704d037a-0ee7-4b6d-848e-fb1f5181d0a9)
